### PR TITLE
vignettes now build with R CMD build; uses BiocStyle

### DIFF
--- a/vignettes/AnnotationHubRecipes.Rmd
+++ b/vignettes/AnnotationHubRecipes.Rmd
@@ -1,8 +1,18 @@
-<!--
-% \VignetteIndexEntry{How to write recipes for new resources for the AnnotationHub}
-% \VignetteDepends{AnnotationHub}
-% \VignetteEngine{knitr::knitr}
--->
+---
+title: "AnnotationHub Recipes"
+author: "Marc Carlson, Sonali Arora"
+date: "`r BiocStyle::doc_date()`"
+package: "`r BiocStyle::pkg_ver('BiocAnnotRes2015')`"
+abstract: >
+  AnnotationHub Recipes
+vignette: >
+  %\VignetteIndexEntry{AnnotationHub Recipes}
+  %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+output: 
+  BiocStyle::html_document:
+    toc: true
+---
 
 ```{r style, echo = FALSE, results = 'asis'}
 BiocStyle::markdown()

--- a/vignettes/AnnotationHubRecipes.Rmd
+++ b/vignettes/AnnotationHubRecipes.Rmd
@@ -113,68 +113,68 @@ makeinparanoid8ToAHMs <- function(currentMetadata){
 Now before we move on on to step two here is a listing of the different arguments that the AnntotationHubMetadata object can take and what class is expected for each of them:
 
 ```{}
-AnnotationHubRoot: ‘character(1)’ Absolute path to directory structure 
+AnnotationHubRoot: 'character(1)' Absolute path to directory structure 
     containing resources to be added to AnnotationHub
 
-SourceUrl: ‘character()’ URL where resource(s) can be found
+SourceUrl: 'character()' URL where resource(s) can be found
 
-SourceType: ‘character()’ which indicates what kind of resource was initially 
+SourceType: 'character()' which indicates what kind of resource was initially 
     processed.  The preference is to name the type of resource if it's a single 
     file type and to name where the resources came from if it is a compound 
     resource.  So Typical answers would be like: 'BED','FASTA' or 'Inparanoid' 
     etc.
 
-SourceVersion: ‘character(1)’ Version of original file
+SourceVersion: 'character(1)' Version of original file
 
-SourceLastModifiedDate: ‘POSIXct()’ The date when the source was last modified. 
+SourceLastModifiedDate: 'POSIXct()' The date when the source was last modified. 
     Leaving this blank should allow the values to be retrieved for you (if your 
     sourceURL is valid).
 
-SourceMd5: ‘character()’ md5 hash of original file
+SourceMd5: 'character()' md5 hash of original file
 
-SourceSize: ‘numeric(1)’ Number of bytes in original file
+SourceSize: 'numeric(1)' Number of bytes in original file
 
-DataProvider: ‘character(1)’ Where did this resource come from?
+DataProvider: 'character(1)' Where did this resource come from?
 
-Title: ‘character(1)’ Title for this resource
+Title: 'character(1)' Title for this resource
 
-Description: ‘character(1)’ Description of the resource
+Description: 'character(1)' Description of the resource
 
-Species: ‘character(1)’ Species name
+Species: 'character(1)' Species name
 
-TaxonomyId: ‘character(1)’ NCBI code
+TaxonomyId: 'character(1)' NCBI code
 
-Genome: ‘character(1)’ Name of genome build
+Genome: 'character(1)' Name of genome build
 
-Tags: ‘character()’ Free-form tags
+Tags: 'character()' Free-form tags
 
-Recipe: ‘character(1)’ Name of recipe function
+Recipe: 'character(1)' Name of recipe function
 
-RDataClass: ‘character(1)’ Class of derived object (e.g. ‘GRanges’)
+RDataClass: 'character(1)' Class of derived object (e.g. 'GRanges')
 
-RDataDateAdded: ‘POSIXct()’ Date added to AnnotationHub. Used to determine 
+RDataDateAdded: 'POSIXct()' Date added to AnnotationHub. Used to determine 
     snapshots.
 
-RDataPath: ‘character(1)’ file path to serialized form
+RDataPath: 'character(1)' file path to serialized form
 
-Maintainer: ‘character(1)’ Maintainer name and email address, ‘A Maintainer 
-    <URL: a.maintainer@email.addr>’
+Maintainer: 'character(1)' Maintainer name and email address, 'A Maintainer 
+    <URL: a.maintainer@email.addr>'
 
-BiocVersion: ‘character(1)’ Under which resource was built
+BiocVersion: 'character(1)' Under which resource was built
 
-Coordinate_1_based: ‘logical(1)’ Do coordinates start with 1 or 0?
+Coordinate_1_based: 'logical(1)' Do coordinates start with 1 or 0?
 
-DispatchClass: ‘character(1)’ string used to indicate which code should be 
+DispatchClass: 'character(1)' string used to indicate which code should be 
     called by the client when the resource is downloaded. This is often the same
     as the RDataClass.  But it is allowed to be a different value so that the 
     client can do something different internally if required.
 
-Location_Prefix: ‘character(1)’ This was added for resources where the metadata 
+Location_Prefix: 'character(1)' This was added for resources where the metadata 
     only is stored and the resource itself comes from a third party web site.  
     The location prefix says the base path where the resource is coming from, 
     and the default value will be from our own site.
 
-Notes: ‘character()’ Notes about the resource.
+Notes: 'character()' Notes about the resource.
 ```
 
 

--- a/vignettes/Annotation_Resources.Rmd
+++ b/vignettes/Annotation_Resources.Rmd
@@ -1,11 +1,23 @@
-<!--
-% \VignetteIndexEntry{Annotation Resources For Bioconductor}
-% \VignetteDepends{AnnotationHub, Homo.sapiens,
+---
+title: "Annotation Resources For Bioconductor"
+author: "Marc Carlson"
+date: "`r BiocStyle::doc_date()`"
+package: "`r BiocStyle::pkg_ver('BiocAnnotRes2015')`"
+abstract: >
+  Annotation Resources For Bioconductor
+vignette: >
+  %\VignetteIndexEntry{Annotation Resources For Bioconductor}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+  %\VignetteDepends{AnnotationHub, Homo.sapiens,
                    TxDb.Hsapiens.UCSC.hg19.knownGene, 
                    BSgenome.Hsapiens.UCSC.hg19, biomaRt,
                    TxDb.Athaliana.BioMart.plantsmart22}
-% \VignetteEngine{knitr::knitr}
--->
+output: 
+  BiocStyle::html_document:
+    toc: true
+---
+
 
 ```{r style, echo = FALSE, results = 'asis'}
 BiocStyle::markdown()


### PR DESCRIPTION
Hi Marc,

I made some changes so allow the vignettes to build with `R CMD build`, they were not building before. I assume you want to use BiocStyle so I made sure that's working too. 

Please accept/merge this pull request.

There is still one problem beyond that, in the 
Annotation_Resources vignette there are still hundreds of lines of the curl progress bar, please apply the fix so that this happens in a hidden code chunk and then again in a non-hidden one. See the problem here:

http://ec2-54-234-109-14.compute-1.amazonaws.com/help/library/BiocAnnotRes2015/doc/Annotation_Resources.html

Let me know if you have questions.

Dan
